### PR TITLE
pixelDialog styling

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {ClipboardModule} from '@angular/cdk/clipboard';
-import {OverlayModule} from '@angular/cdk/overlay';
+import {MatDialogModule} from '@angular/material/dialog';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 
 @NgModule({
@@ -25,7 +25,7 @@ import {MatSnackBarModule} from '@angular/material/snack-bar';
     MatButtonModule,
     MatIconModule,
     ClipboardModule,
-    OverlayModule,
+    MatDialogModule,
     MatSnackBarModule
   ],
   providers: [],

--- a/src/app/component/pixel-container/pixel-container.component.html
+++ b/src/app/component/pixel-container/pixel-container.component.html
@@ -1,7 +1,6 @@
 <div>
   <app-pixel
   *ngFor="let pixel of PixelNumberArray"
-  cdkOverlayOrigin #trigger="cdkOverlayOrigin"
   [height]="pixelHeight"
   >
 </app-pixel>

--- a/src/app/component/pixel-dialog/pixel-dialog.component.html
+++ b/src/app/component/pixel-dialog/pixel-dialog.component.html
@@ -1,22 +1,20 @@
-<div id="pixel-dialog">
-  <h1 id="pixel-dialog-heading">Pixel Color</h1>
+<h1 id="pixel-dialog-heading">Pixel Color</h1>
 
-  <div class="color-selector">
-    <p>{{colorString}}</p>
-    <button mat-mini-fab [cdkCopyToClipboard]="colorString" (click)="openSnackbar(colorString)">
-      <mat-icon>content_copy</mat-icon>
-    </button>
-  </div>
-  <div class="color-selector">
-    <p>{{rgbColorString}}</p>
-    <button mat-mini-fab [cdkCopyToClipboard]="rgbColorString" (click)="openSnackbar(rgbColorString)">
-      <mat-icon>content_copy</mat-icon>
-    </button>
-  </div>
-  <div class="color-selector">
-    <p>{{hslColorString}}</p>
-    <button mat-mini-fab [cdkCopyToClipboard]="hslColorString" (click)="openSnackbar(hslColorString)">
-      <mat-icon>content_copy</mat-icon>
-    </button>
-  </div>
+<div class="color-selector">
+  <p>{{data.colorString}}</p>
+  <button mat-mini-fab [cdkCopyToClipboard]="data.colorString" (click)="openSnackbar(data.colorString)">
+    <mat-icon>content_copy</mat-icon>
+  </button>
+</div>
+<div class="color-selector">
+  <p>{{rgbColorString}}</p>
+  <button mat-mini-fab [cdkCopyToClipboard]="rgbColorString" (click)="openSnackbar(rgbColorString)">
+    <mat-icon>content_copy</mat-icon>
+  </button>
+</div>
+<div class="color-selector">
+  <p>{{hslColorString}}</p>
+  <button mat-mini-fab [cdkCopyToClipboard]="hslColorString" (click)="openSnackbar(hslColorString)">
+    <mat-icon>content_copy</mat-icon>
+  </button>
 </div>

--- a/src/app/component/pixel-dialog/pixel-dialog.component.scss
+++ b/src/app/component/pixel-dialog/pixel-dialog.component.scss
@@ -1,17 +1,3 @@
-#pixel-dialog {
-  height: 225px;
-  width: 225px;
-  border-radius: 15%;
-  z-index: 5;
-  position: fixed;
-  background-color: white;
-  padding-left: 10px;
-}
-
-#pixel-dialog-heading {
-  margin-top: 10px;
-}
-
 .color-selector {
   display: flex;
   height: 50px;

--- a/src/app/component/pixel-dialog/pixel-dialog.component.ts
+++ b/src/app/component/pixel-dialog/pixel-dialog.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 @Component({
   selector: 'app-pixel-dialog',
@@ -7,7 +8,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./pixel-dialog.component.scss'],
 })
 export class PixelDialogComponent implements OnInit {
-  @Input() colorString: string = '';
 
   rgbColor = {
     red: 0,
@@ -25,7 +25,10 @@ export class PixelDialogComponent implements OnInit {
 
   hslColorString = '';
 
-  constructor(private _snackBar: MatSnackBar) {}
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private _snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {
     this.convertColorToRGB();
@@ -33,9 +36,9 @@ export class PixelDialogComponent implements OnInit {
   }
 
   convertColorToRGB(): void {
-    this.rgbColor.red = parseInt(this.colorString.substring(1, 3), 16);
-    this.rgbColor.green = parseInt(this.colorString.substring(3, 5), 16);
-    this.rgbColor.blue = parseInt(this.colorString.substring(5), 16);
+    this.rgbColor.red = parseInt(this.data.colorString.substring(1, 3), 16);
+    this.rgbColor.green = parseInt(this.data.colorString.substring(3, 5), 16);
+    this.rgbColor.blue = parseInt(this.data.colorString.substring(5), 16);
     this.rgbColorString = `rgb(${this.rgbColor.red},${this.rgbColor.green},${this.rgbColor.blue})`;
   }
 
@@ -82,7 +85,7 @@ export class PixelDialogComponent implements OnInit {
 
   openSnackbar(colorValue: string): void {
     this._snackBar.open(`Color value: ${colorValue}`, " Copied to clipboard", {
-      duration:  5000,
+      duration:  5000
     });
   }
 }

--- a/src/app/component/pixel/pixel.component.html
+++ b/src/app/component/pixel/pixel.component.html
@@ -2,20 +2,6 @@
 [style.background-color]="color"
 [style.height.px]="height"
 [style.width.px]="height"
-(click)="toggleDialog($event)"
-
+(click)="openDialog()"
 >
 </div>
-
-<ng-template
-  cdkConnectedOverlay
-  [cdkConnectedOverlayOrigin]="triggerOrigin"
-  [cdkConnectedOverlayHasBackdrop]="true"
-  (backdropClick)="overlayIsOpen = false"
-  [cdkConnectedOverlayOpen]="overlayIsOpen"
->
-  <app-pixel-dialog
-  [colorString]="color"
-  (mouseleave)="overlayIsOpen = false">
-  </app-pixel-dialog>
-</ng-template>

--- a/src/app/component/pixel/pixel.component.ts
+++ b/src/app/component/pixel/pixel.component.ts
@@ -1,4 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
+import { PixelDialogComponent } from '../pixel-dialog/pixel-dialog.component';
+
 
 @Component({
   selector: 'app-pixel',
@@ -14,7 +17,7 @@ export class PixelComponent implements OnInit {
   overlayIsOpen = false;
   triggerOrigin: any;
 
-  constructor() {}
+  constructor(public dialog: MatDialog) {}
 
   ngOnInit(): void {
     this.getRandomColor();
@@ -27,8 +30,11 @@ export class PixelComponent implements OnInit {
     }
   }
 
-  toggleDialog(trigger: any) {
-    this.triggerOrigin = trigger;
-    this.overlayIsOpen = !this.overlayIsOpen;
+  openDialog() {
+  this.dialog.open(PixelDialogComponent, {
+    data: {
+      colorString: this.color,
+    }
+  });
   }
 }


### PR DESCRIPTION
- removed OverlayModule and replaced with DialogModule
- opening pixelDialog as Dialog instead of Overlay
- pixelDialog now is always in the center
- removed pixelDialog container div and its styling